### PR TITLE
fix(LuaGlueApplyTuple.h): Fix compilation error

### DIFF
--- a/include/LuaGlue/LuaGlueApplyTuple.h
+++ b/include/LuaGlue/LuaGlueApplyTuple.h
@@ -1,6 +1,8 @@
 #ifndef LUAGLUE_APPLYTUPLE_H_GUARD
 #define LUAGLUE_APPLYTUPLE_H_GUARD
 
+#define luaL_checkint(L,n)	((int)luaL_checkinteger(L, (n)))
+
 #include <cstdint>
 #include <tuple>
 #include <lua.hpp>


### PR DESCRIPTION
Fix the error below when compiling on Arch

-- 
-- MMEX configuration summary
-- ==========================
-- Version        : 1.3.5
-- Host system    : Linux x86_64
-- Target system  : Linux x86_64
-- Build types    : Release
-- Generator      : Unix Makefiles
-- Install prefix : /usr
-- DB encryption  : ON
-- 
-- Versions
-- --========--
-- Linux 5.7.12-arch1-1
-- Arch 5.7.12-arch1-1
-- CMake 3.18.1
-- GNU Make 4.3
-- ccache 3.7.11
-- GNU 10.1.0
-- wxWidgets 3.0.5
-- wxSQLite3 4.6.0
-- Lua 5.4.0
-- curl 7.71.1
-- gettext 0.20.2

Error: Building CXX object src/CMakeFiles/mmex.dir/optiondialog.cpp.o:
LuaGlueApplyTuple.h:20:11: error: there are no arguments to ‘luaL_checkint’ that depend on a template parameter, so a declaration of ‘luaL_checkint’ must be available [-fpermissive]
   20 |  int id = luaL_checkint(s, -1);
      |           ^~~~~~~~~~~~~